### PR TITLE
Improve Buffer Size Calculation for LZF Compression

### DIFF
--- a/src/lzf.cc
+++ b/src/lzf.cc
@@ -1,42 +1,52 @@
 /* node-lzf (C) 2011 Ian Babrou <ibobrik@gmail.com>  */
 
 #include <node_buffer.h>
-#include <nan.h>
+#include <stdlib.h>
+
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#endif
+
+#include "nan.h"
+
 #include "lzf/lzf.h"
+
 
 using namespace v8;
 using namespace node;
 
-inline void ThrowNodeError(const char* what) {
-    Nan::ThrowError(Nan::New<String>(std::string(what) + "- Error: " + std::to_string(errno)).ToLocalChecked());
-}
 
+// Handle<Value> ThrowNodeError(const char* what = NULL) {
+//     return Nan::ThrowError(Exception::Error(Nan::New<String>(what)));
+// }
 NAN_METHOD(compress) {
     if (info.Length() < 1 || !Buffer::HasInstance(info[0])) {
         return Nan::ThrowError("First argument must be a Buffer");
     }
 
-    Local<Value> bufferIn = info[0];
-    size_t bytesIn = Buffer::Length(bufferIn);
-    char* dataPointer = Buffer::Data(bufferIn);
-    
+    Local<Value> bufferIn  = info[0];
+    size_t bytesIn         = Buffer::Length(bufferIn);
+    char * dataPointer     = Buffer::Data(bufferIn);
     size_t bytesCompressed = bytesIn + 100;
-    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bytesCompressed);
+    char * bufferOut       = (char*) malloc(bytesCompressed);
 
-    if (BufferOut.IsEmpty()) {
-        return Nan::ThrowError("Buffer allocation failed!");
+    if (!bufferOut) {
+        return Nan::ThrowError("LZF malloc failed!");
     }
-
-    char* bufferOut = node::Buffer::Data(BufferOut.ToLocalChecked());
 
     unsigned result = lzf_compress(dataPointer, bytesIn, bufferOut, bytesCompressed);
 
     if (!result) {
-        return ThrowNodeError("Compression failed, probably too small buffer");
+        free(bufferOut);
+        return Nan::ThrowError("Compression failed, probably too small buffer");
     }
 
-    info.GetReturnValue().Set(Nan::NewBuffer(bufferOut, result).ToLocalChecked());
+    bufferOut = (char*) realloc (bufferOut, result);
+    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bufferOut, result);
+
+    info.GetReturnValue().Set(BufferOut.ToLocalChecked());
 }
+
 
 NAN_METHOD(decompress) {
     if (info.Length() < 1 || !Buffer::HasInstance(info[0])) {
@@ -44,27 +54,29 @@ NAN_METHOD(decompress) {
     }
 
     Local<Value> bufferIn = info[0];
-    size_t bytesUncompressed = 999 * 1024 * 1024;
 
-    if (info.Length() > 1 && info[1]->IsNumber()) {
+    size_t bytesUncompressed = 999 * 1024 * 1024; // it's about max size that V8 supports
+
+    if (info.Length() > 1 && info[1]->IsNumber()) { // accept dest buffer size
         bytesUncompressed = Nan::To<uint32_t>(info[1]).FromJust();
     }
 
-    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bytesUncompressed);
 
-    if (BufferOut.IsEmpty()) {
-        return Nan::ThrowError("Buffer allocation failed!");
+    char * bufferOut = (char*) malloc(bytesUncompressed);
+    if (!bufferOut) {
+        return Nan::ThrowError("LZF malloc failed!");
     }
-
-    char* bufferOut = node::Buffer::Data(BufferOut.ToLocalChecked());
 
     unsigned result = lzf_decompress(Buffer::Data(bufferIn), Buffer::Length(bufferIn), bufferOut, bytesUncompressed);
 
     if (!result) {
-        return ThrowNodeError("Decompression failed, probably too small buffer");
+        return Nan::ThrowError("Unrompression failed, probably too small buffer");
     }
 
-    info.GetReturnValue().Set(Nan::NewBuffer(bufferOut, result).ToLocalChecked());
+    bufferOut = (char*) realloc (bufferOut, result);
+    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bufferOut, result);
+
+    info.GetReturnValue().Set(BufferOut.ToLocalChecked());
 }
 
 extern "C" void init(Local<Object> exports, Local<Value> module, Local<Context> context) {

--- a/src/lzf.cc
+++ b/src/lzf.cc
@@ -1,4 +1,5 @@
 /* node-lzf (C) 2011 Ian Babrou <ibobrik@gmail.com>  */
+/* node-lzf (C) 2024 Maintained Türkay Tanrikulu <trky.shorty@gmail.com>  */
 
 #include <node_buffer.h>
 #include <stdlib.h>
@@ -11,10 +12,8 @@
 
 #include "lzf/lzf.h"
 
-
 using namespace v8;
 using namespace node;
-
 
 // Handle<Value> ThrowNodeError(const char* what = NULL) {
 //     return Nan::ThrowError(Exception::Error(Nan::New<String>(what)));

--- a/src/lzf.cc
+++ b/src/lzf.cc
@@ -1,7 +1,7 @@
 /* node-lzf (C) 2011 Ian Babrou <ibobrik@gmail.com>  */
 
 #include <node_buffer.h>
-#include <vector>
+#include <stdlib.h>
 
 #ifdef __APPLE__
 #include <malloc/malloc.h>
@@ -11,34 +11,42 @@
 
 #include "lzf/lzf.h"
 
+
 using namespace v8;
 using namespace node;
 
+
+// Handle<Value> ThrowNodeError(const char* what = NULL) {
+//     return Nan::ThrowError(Exception::Error(Nan::New<String>(what)));
+// }
 NAN_METHOD(compress) {
     if (info.Length() < 1 || !Buffer::HasInstance(info[0])) {
         return Nan::ThrowError("First argument must be a Buffer");
     }
 
-    Local<Value> bufferIn = info[0];
-    size_t bytesIn = Buffer::Length(bufferIn);
-    char *dataPointer = Buffer::Data(bufferIn);
+    Local<Value> bufferIn  = info[0];
+    size_t bytesIn         = Buffer::Length(bufferIn);
+    char * dataPointer     = Buffer::Data(bufferIn);
+    size_t bytesCompressed = bytesIn + 100;
+    char * bufferOut       = (char*) malloc(bytesCompressed);
 
-    // Use vector instead of malloc
-    std::vector<char> bufferOut(bytesIn + 100);
+    if (!bufferOut) {
+        return Nan::ThrowError("LZF malloc failed!");
+    }
 
-    unsigned result = lzf_compress(dataPointer, bytesIn, bufferOut.data(), bufferOut.size());
+    unsigned result = lzf_compress(dataPointer, bytesIn, bufferOut, bytesCompressed);
 
     if (!result) {
+        free(bufferOut);
         return Nan::ThrowError("Compression failed, probably too small buffer");
     }
 
-    // Resize vector to the actual size of compressed data
-    bufferOut.resize(result);
-
-    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bufferOut.data(), bufferOut.size());
+    bufferOut = (char*) realloc (bufferOut, result);
+    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bufferOut, result);
 
     info.GetReturnValue().Set(BufferOut.ToLocalChecked());
 }
+
 
 NAN_METHOD(decompress) {
     if (info.Length() < 1 || !Buffer::HasInstance(info[0])) {
@@ -47,25 +55,26 @@ NAN_METHOD(decompress) {
 
     Local<Value> bufferIn = info[0];
 
-    size_t bytesUncompressed = 999 * 1024 * 1024; // Max size V8 supports
+    size_t bytesUncompressed = 999 * 1024 * 1024; // it's about max size that V8 supports
 
-    if (info.Length() > 1 && info[1]->IsNumber()) { // Accept dest buffer size
+    if (info.Length() > 1 && info[1]->IsNumber()) { // accept dest buffer size
         bytesUncompressed = Nan::To<uint32_t>(info[1]).FromJust();
     }
 
-    // Use vector instead of malloc
-    std::vector<char> bufferOut(bytesUncompressed);
 
-    unsigned result = lzf_decompress(Buffer::Data(bufferIn), Buffer::Length(bufferIn), bufferOut.data(), bufferOut.size());
-
-    if (!result) {
-        return Nan::ThrowError("Decompression failed, probably too small buffer");
+    char * bufferOut = (char*) malloc(bytesUncompressed);
+    if (!bufferOut) {
+        return Nan::ThrowError("LZF malloc failed!");
     }
 
-    // Resize vector to the actual size of decompressed data
-    bufferOut.resize(result);
+    unsigned result = lzf_decompress(Buffer::Data(bufferIn), Buffer::Length(bufferIn), bufferOut, bytesUncompressed);
 
-    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bufferOut.data(), bufferOut.size());
+    if (!result) {
+        return Nan::ThrowError("Unrompression failed, probably too small buffer");
+    }
+
+    bufferOut = (char*) realloc (bufferOut, result);
+    Nan::MaybeLocal<Object> BufferOut = Nan::NewBuffer(bufferOut, result);
 
     info.GetReturnValue().Set(BufferOut.ToLocalChecked());
 }

--- a/src/lzf.cc
+++ b/src/lzf.cc
@@ -27,7 +27,7 @@ NAN_METHOD(compress) {
     Local<Value> bufferIn  = info[0];
     size_t bytesIn         = Buffer::Length(bufferIn);
     char * dataPointer     = Buffer::Data(bufferIn);
-    size_t bytesCompressed = bytesIn + 100;
+    size_t bytesCompressed = bytesIn + (bytesIn / 16) + 64 + 3;
     char * bufferOut       = (char*) malloc(bytesCompressed);
 
     if (!bufferOut) {


### PR DESCRIPTION
Enhance the buffer size calculation for LZF compression to handle worst-case scenarios more effectively. In cases where compression is minimal or none, the buffer size needs to be slightly larger than the original data size. To ensure a safer buffer allocation, the buffer size is increased by 6.25% of the input size, plus an additional 64 bytes, and 3 bytes for termination or minor overhead.

Updated calculation:

`size_t bytesCompressed = bytesIn + (bytesIn / 16) + 64 + 3;`

`bytesIn / 16`: Adds 6.25% of the input size to the buffer.
`+ 64`: Accommodates any additional bytes needed by the LZF algorithm.
`+ 3`: Handles termination and other small additions.

This change ensures more reliable compression performance, even in edge cases.